### PR TITLE
Upgrading from FlashAttention (1.x) to FlashAttention-2, the fucntion…

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ pip install protobuf==3.20.0
 3. Install additional packages for training cases
 ```
 pip install ninja
+pip install tensorboard
 pip install flash-attn==1.0.7 --no-build-isolation
 ```
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ pip install protobuf==3.20.0
 3. Install additional packages for training cases
 ```
 pip install ninja
-pip install flash-attn --no-build-isolation
+pip install flash-attn==1.0.7 --no-build-isolation
 ```
 
 


### PR DESCRIPTION
Upgrading from FlashAttention (1.x) to FlashAttention-2,  `flash_attn_unpadded_qkvpacked_func` has been renamed and gives error.
Reference - https://github.com/Dao-AILab/flash-attention/issues/318#issuecomment-1756153770

Also, during finetuning we're getting runtime RuntimeError: TensorBoardCallback in FERRETTrainer requires tensorboard to be installed. Either update your PyTorch version or install tensorboardX. So, tensorboard is an important dependency